### PR TITLE
Fix duplicate length field

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,9 +88,8 @@ PREFIX_TOKEN <category_id> <has_nonfungible> [commitment] <amount>
    3. `0xfe` (the **`mutable` capability**) – the encoded non-fungible token is considered a **mutable token**.
    4. `0xfd` (no capability) – the encoded non-fungible token has a commitment length of `0`. Skip to `amount`.
    5. `0x01`-`0x28` – This byte is a `commitment_length` (encoded as a single-byte `VarInt`<sup>1</sup>) for the encoded non-fungible token. Skip to `commitment`.
-3. `commitment_length` – A **commitment length** (encoded as a single-byte `VarInt`<sup>1</sup>) with a minimum value of `0` (`0x00`) and maximum value of `40` (`0x28`).
-4. `commitment` – If `commitment_length` is non-zero, a **token commitment** of `commitment_length` is required.
-5. `amount` – a **token amount** (encoded as a `VarInt`) with a minimum value of `0` (`0x00`) and a maximum value equal to the maximum VM number, `9223372036854775807` (`ffffffffffffffff7f`).
+3. `commitment` – If `commitment_length` is non-zero, a **token commitment** of `commitment_length` is required.
+4. `amount` – a **token amount** (encoded as a `VarInt`) with a minimum value of `0` (`0x00`) and a maximum value equal to the maximum VM number, `9223372036854775807` (`ffffffffffffffff7f`).
 
 `PREFIX_TOKEN` must encode at least one token (non-fungible, fungible, or both).
 


### PR DESCRIPTION
You likely merged the length into the has_nonfungible, but forgot to remove the now duplicate.