### PR TITLE
Recommended changes: We need to not imply that anybody should be pruning UTXOs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -440,7 +440,7 @@ Prior to activation, PATFOs remain **nonstandard** but do not invalidate the tra
 
 Note, even properly-encoded token outputs included in transactions mined prior to activation are considered PATFOs, regardless of whether or not the transaction would pass token-aware transaction validation after activation. Due to the possibility of a chain re-organization impacting the precise activation time, token issuers are advised to wait until activation is confirmed to a depth of at least 11 blocks before broadcasting critical transactions involving tokens.
 
-PATFOs are provably unspendable<sup>1</sup>; all software implementing this specification should immediately mark PATFOs as unspendable and/or remove them from their local view of the UTXO set (e.g. on startup and upon receipt).
+PATFOs are provably unspendable<sup>1</sup>; all software implementing this specification should immediately mark PATFOs as unspendable and/or logically treat them as such for the purposes of spending.
 
 **By consensus, PATFOs mined in blocks prior to the activation of [Token-Aware Transaction Validation](#token-aware-transaction-validation) must remain unspendable after activation**. (Please note: the presence of PATFOs does not render a transaction invalid; until activation, valid blocks may contain PATFOs.)
 
@@ -450,7 +450,7 @@ After activation, any transaction creating an invalid token prefix<sup>2</sup> i
 
 <summary>Notes</summary>
 
-1. For pre-activation token-forgery outputs (PATFOs), this has been the case for even longer than `OP_RETURN` outputs: PATFOs have been provably unspendable since the Bitcoin Cash protocol's publication in 2008. As such, they can be safely pruned without activation and at no risk of network consensus failures.
+1. For pre-activation token-forgery outputs (PATFOs), this has been the case for even longer than `OP_RETURN` outputs: PATFOs have been provably unspendable since the Bitcoin Cash protocol's publication in 2008.
 2. That is, any transaction output where locking bytecode index `0` is set to the `PREFIX_TOKEN` codepoint, but a valid token prefix cannot be parsed.
 
 </details>


### PR DESCRIPTION
Rationale -- this will have bad interactions with stuff like UTXO set commitments if nodes adopt different behavior here (some delete, some don't, etc).  For now, PATFOs should just forever live in the UTXO set since deletion is problematic due to the way activation works.  Logically speaking, unupgraded nodes won't be "pruning" until they upgrade.  

If this recommendation to prune is followed, it means that the set of all UTXOs has a different definition (potentially) and different set membership depending upon non-deterministic real-world chaotic factors such as when in time a user decided to install a new version of e.g. BCHN!

This is theoretically problematic for something like UTXO commitments or UTXO fast sync. The set of all UTXOs needs to have a stable definition across time and space for UTXO commitments to work...

See: https://bitcoincashresearch.org/t/chip-2021-07-utxo-fastsync